### PR TITLE
Do not update symbols tree when not visible

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
       "id": "lsp",
       "name": "Language Server Protocol",
       "description": "Provides intellisense by leveraging the LSP protocol.",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "mod_version": "3.4.0",
       "dependencies": {
         "lintplus": { "version": ">=0.2" },


### PR DESCRIPTION
Other changes:

* Cache current doc symbols to reduce the amount of requests sent to                 
lsp server when switching from one view back to a previous one.                      
* Update symbols tree only when user finishes typing.