### PR TITLE
Allow configuring the symbols tree width.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -110,6 +110,7 @@ config.plugins.lsp = common.merge({
   more_yielding = false,
   autostart_server = true,
   symbolstree_visibility = "auto",
+  symbolstree_width = 300 * SCALE,
   -- The config specification used by the settings gui
   config_spec = {
     name = "Language Server Protocol",
@@ -239,6 +240,22 @@ config.plugins.lsp = common.merge({
             lsp.symbols_tree:hide()
           end
         end
+      end
+    },
+    {
+      label = "Symbols Tree Width",
+      description = "Default width for the symbols tree pane.",
+      path = "symbolstree_width",
+      type = "number",
+      default = 300 * SCALE,
+      get_value = function(value)
+        return value / SCALE
+      end,
+      set_value = function(value)
+        return value * SCALE
+      end,
+      on_apply = function(value)
+        lsp.symbols_tree:set_size(value)
       end
     }
   }
@@ -2471,7 +2488,7 @@ end
 --
 lsp.symbols_tree = SymbolsTree()
 lsp.symbols_tree:hide()
-lsp.symbols_tree:set_size(300 * SCALE, 100)
+lsp.symbols_tree:set_size(config.plugins.lsp.symbolstree_width, 100)
 if config.plugins.lsp.symbolstree_visibility == "auto" then
   lsp.symbols_tree:set_auto_hide(true)
 elseif config.plugins.lsp.symbolstree_visibility == "show" then

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
       "id": "lsp",
       "name": "Language Server Protocol",
       "description": "Provides intellisense by leveraging the LSP protocol.",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "mod_version": "3.4.0",
       "dependencies": {
         "lintplus": { "version": ">=0.2" },


### PR DESCRIPTION
Fixes pragtical/pragtical#203

![symbolstree-width](https://github.com/user-attachments/assets/a2842761-269d-4491-855f-071abd1c4d65)
