### PR TITLE
fix: teal-language-server

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -979,7 +979,6 @@ lspconfig.teal_language_server = add_lsp {
   language = "teal",
   file_patterns = { "%.tl$" },
   command = { "teal-language-server" },
-  env = { TL_PATH="?.tl;src/?.tl" },
   verbose = false
 }
 


### PR DESCRIPTION
remove TL_PATH as wrong. Use `tlconfig.lua`'s `include_dir` instead.